### PR TITLE
Add CI job timeouts and fix Playwright install hangs

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -33,6 +33,7 @@ jobs:
     name: 🔒 Security Audit
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -117,6 +118,7 @@ jobs:
     name: 🔎 Dependency Review
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -137,6 +139,7 @@ jobs:
     name: 🔍 Verify Mock Files
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -173,6 +176,7 @@ jobs:
     needs: dependency-guard
     if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -231,6 +235,7 @@ jobs:
     needs: dependency-guard
     if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -322,6 +327,7 @@ jobs:
     needs: dependency-guard
     if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -396,6 +402,7 @@ jobs:
     needs: test-frontend
     if: always() && needs.test-frontend.result == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -441,6 +448,7 @@ jobs:
     needs: dependency-guard
     if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && (github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' || github.event_name == 'merge_group') }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -476,6 +484,7 @@ jobs:
     needs: build
     if: ${{ always() && needs.build.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         database: [sqlite, postgres, redis]
@@ -575,6 +584,7 @@ jobs:
     needs: [build, build_samples]
     if: ${{ always() && needs.build.result == 'success' && needs.build_samples.result == 'success' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -756,9 +766,17 @@ jobs:
         run: npm ci
         working-directory: tests/e2e
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+      - name: Install Playwright System Dependencies
+        run: npx playwright install-deps
         working-directory: tests/e2e
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
+      - name: Install Playwright Browsers
+        run: npx playwright install
+        working-directory: tests/e2e
+        timeout-minutes: 5
 
       - name: Run Playwright tests
         run: npx playwright test
@@ -793,6 +811,7 @@ jobs:
     name: 🔍 Detect PowerShell Changes
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       should-run: ${{ steps.filter.outputs.powershell }}
     steps:
@@ -817,6 +836,7 @@ jobs:
     name: 🔍 Detect Documentation Changes
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       should-run: ${{ steps.filter.outputs.docs }}
     steps:
@@ -844,6 +864,7 @@ jobs:
     needs: [dependency-guard, detect-docs-changes]
     if: ${{ always() && (needs.dependency-guard.result == 'success' || needs.dependency-guard.result == 'skipped') && needs.detect-docs-changes.outputs.should-run == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: 📥 Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/windows-build-validation.yml
+++ b/.github/workflows/windows-build-validation.yml
@@ -425,6 +425,7 @@ jobs:
       - name: 🎭 Install Playwright Browsers
         working-directory: tests/e2e
         run: npx playwright install --with-deps chromium
+        timeout-minutes: 5
 
       - name: 🔍 Verify Services Before Tests
         shell: pwsh

--- a/tests/e2e/.github/workflows/e2e-tests.yml
+++ b/tests/e2e/.github/workflows/e2e-tests.yml
@@ -31,9 +31,17 @@ jobs:
         working-directory: tests/e2e
         run: npm ci
 
+      - name: Install Playwright System Dependencies
+        working-directory: tests/e2e
+        run: npx playwright install-deps ${{ matrix.browser }}
+        timeout-minutes: 5
+        env:
+          DEBIAN_FRONTEND: noninteractive
+
       - name: Install Playwright Browsers
         working-directory: tests/e2e
-        run: npx playwright install --with-deps ${{ matrix.browser }}
+        run: npx playwright install ${{ matrix.browser }}
+        timeout-minutes: 5
 
       - name: Run E2E tests
         working-directory: tests/e2e


### PR DESCRIPTION
### Purpose

Address two CI reliability problems:

1. **Playwright install step intermittently hangs** during `npx playwright install --with-deps`, causing the whole job to run for the default 6-hour timeout before failing. Root cause is apt-get hanging on an interactive debconf prompt during system dependency install (see [microsoft/playwright#20665](https://github.com/microsoft/playwright/issues/20665)).
2. **No job-level timeouts** anywhere in the PR Builder workflow, so any stuck step burns 6 hours of runner time.

### Approach

**Playwright install (Linux runners):** Split `npx playwright install --with-deps` into two separate steps and set `DEBIAN_FRONTEND=noninteractive`:
- `npx playwright install-deps` — apt portion, where the hang occurs. 5 min timeout.
- `npx playwright install` — browser binary download. 5 min timeout.

This makes the apt step non-interactive (the actual fix) and gives clearer logs when something does fail. On the Windows validation workflow, `--with-deps` is effectively a no-op (Playwright only installs apt deps on Linux), so that step is left combined and just gets a 5-minute step timeout.

**Job timeouts in PR Builder:** Added `timeout-minutes: 30` to standalone jobs and `timeout-minutes: 40` to `test-e2e` (longest job, ~25 min real runtime + buffer). Skipped the two jobs that call reusable workflows (`dependency-guard`, `validate-windows`) since `timeout-minutes` can't be set from the caller side.

Files changed:
- `.github/workflows/pr-builder.yml`
- `.github/workflows/windows-build-validation.yml`
- `tests/e2e/.github/workflows/e2e-tests.yml`

### Related Issues
- N/A

### Related PRs
- N/A

### Checklist
- [x] Followed the contribution guidelines.
- [ ] Manual test round performed and verified.
- [ ] Documentation provided. (Add links if there are any)
    - [ ] Ran Vale and fixed all errors and warnings
- [ ] Tests provided. (Add links if there are any)
    - [ ] Unit Tests
    - [ ] Integration Tests
- [ ] Breaking changes. (Fill if applicable)
    - [ ] Breaking changes section filled.
    - [ ] \`breaking change\` label added.

### Security checks
- [x] Followed secure coding standards in [WSO2 Secure Coding Guidelines](https://security.docs.wso2.com/en/latest/security-guidelines/secure-engineering-guidelines/secure-coding-guidlines/introduction/)
- [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)